### PR TITLE
Task 7 - Lambda Authorizer + Cognito Authorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "brickage-client",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brickage-client",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -38,6 +38,10 @@ export class ManageProductsService extends ApiService {
         params: {
           name: fileName,
         },
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          Authorization: localStorage.getItem('authorization_token') ?? '',
+        },
       })
       .pipe(map(({ presignedUrl }) => presignedUrl));
   }

--- a/src/app/core/interceptors/error-print.interceptor.ts
+++ b/src/app/core/interceptors/error-print.interceptor.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import {
+  HttpErrorResponse,
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
@@ -19,13 +20,23 @@ export class ErrorPrintInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       tap({
-        error: () => {
+        error: (error: unknown) => {
           const url = new URL(request.url);
 
-          this.notificationService.showError(
-            `Request to "${url.pathname}" failed. Check the console for the details`,
-            0
-          );
+          switch ((error as HttpErrorResponse)?.status) {
+            case 403:
+              this.notificationService.showAlert(`Access denied (403)`, 1000);
+              break;
+            case 401:
+              this.notificationService.showError(`Unauthorized (401)`, 1000);
+              break;
+            default:
+              this.notificationService.showError(
+                `Request to "${url.pathname}" failed. Check the console for the details`,
+                0
+              );
+              break;
+          }
         },
       })
     );

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -19,4 +19,17 @@ export class NotificationService {
       panelClass: 'shop-snackbar-error',
     });
   }
+
+  /**
+   * Show message with an alert
+   *
+   * @param text Error text message
+   * @param duration Duration to close after. 0 to close manually only
+   */
+  showAlert(text: string, duration = 3000) {
+    this.snackBar.open(text, 'Dismiss', {
+      duration,
+      panelClass: 'shop-snackbar-alert',
+    });
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -31,3 +31,13 @@ body {
     border: 1px solid;
   }
 }
+
+.shop-snackbar-alert {
+  background-color: #ffa012;
+  color: white;
+
+  button {
+    color: white;
+    border: 1px solid;
+  }
+}


### PR DESCRIPTION
## Task description

The task goal is to create a simple Lambda auth
_[source](https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/task7-lambda+cognito-authorization/task.md)_


### What was done

- Add import-request header with auth
- Add 401 & 403 error codes notifications
